### PR TITLE
End code block in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ try (Log<Debug> log = loggers.debug("saveFile")) {
    log.add("to", newFile);
    // do some complicated logic here, and add different properties to the log record depending what happens
 }
+```
 
 Usage
 -----


### PR DESCRIPTION
There were three backticks missing, making the rest of the readme render as code.